### PR TITLE
Rename project from 'r-package-template' to 'rpt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# r-package-template
+# rpt (R package template)
 A template for R packages


### PR DESCRIPTION
"r.package.template" was misunderstood by mac os as an executable