### PR TITLE
Remove container image and add R setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -66,7 +66,7 @@ jobs:
             any::rmarkdown
           needs: check
 
-            # Set up Quarto - required for rendering the website
+      # Set up Quarto - required for rendering the website
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:


### PR DESCRIPTION
seems to break copilot agent

This pull request updates the GitHub Actions workflow for Copilot setup steps by removing the use of a Docker container and switching to explicit setup steps for Pandoc and R. The main goal is to improve flexibility and clarity in the workflow configuration.

**Workflow environment changes:**

* Removed the `rocker/verse:latest` Docker container, so the workflow now runs directly on `ubuntu-latest` instead of inside a preconfigured R environment.

**Explicit setup steps:**

* Added separate steps to set up Pandoc (`r-lib/actions/setup-pandoc@v2`) and R (`r-lib/actions/setup-r@v2`), specifying the use of the latest R release and enabling the public RSPM repository.