### PR TITLE
ignore altdoc/pkgdown.yml

### DIFF
--- a/altdoc/.gitignore
+++ b/altdoc/.gitignore
@@ -1,0 +1,1 @@
+pkgdown.yml

--- a/altdoc/pkgdown.yml
+++ b/altdoc/pkgdown.yml
@@ -1,8 +1,0 @@
-altdoc: 0.7.0
-pandoc: 3.1.11
-pkgdown: 2.1.3
-pkgdown_sha: ~
-last_built: 2026-01-29T11:43:43+0000
-urls:
-  reference: https://ucd-serg.github.io/rpt/man
-  article: https://ucd-serg.github.io/rpt/vignettes


### PR DESCRIPTION
This pull request makes a minor update to the project's configuration files by removing the `pkgdown.yml` file and adding it to `.gitignore` to prevent it from being tracked in the repository.

- Configuration cleanup:
  * Removed the `pkgdown.yml` file from the repository to declutter version control.
  * Added `pkgdown.yml` to `.gitignore` to ensure it is not tracked in future commits.