### PR TITLE
fix dark-mode code background

### DIFF
--- a/altdoc/quarto_website.yml
+++ b/altdoc/quarto_website.yml
@@ -63,7 +63,7 @@ format:
     theme:
       light: default
       dark: darkly
-    css: altdoc/styles.css
+    css: styles.css
     number-sections: false
     code-copy: true
     code-overflow: scroll


### PR DESCRIPTION
This pull request makes a minor update to the Quarto website configuration by changing the path to the custom CSS file. The `css` setting now references `styles.css` instead of `altdoc/styles.css`.