### PR TITLE
set timeout minutes per step

### DIFF
--- a/.github/workflows/altdoc.yaml
+++ b/.github/workflows/altdoc.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   altdoc:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: altdoc-${{ github.event_name != 'pull_request' || github.run_id }}
@@ -92,6 +92,7 @@ jobs:
         # uncomment the next two lines to get full debugging output
         # env:
           # QUARTO_LOG_LEVEL: DEBUG
+        timeout-minutes: 20
         run: |
           # If parallel = TRUE in render_docs()
           # future::plan(future::multicore)


### PR DESCRIPTION
This pull request updates the workflow configuration for the documentation build process, primarily by increasing timeout limits to help prevent job failures due to time constraints.

Workflow configuration updates:

* Increased the overall job timeout for the `altdoc` job from 15 minutes to 30 minutes in `.github/workflows/altdoc.yaml`.
* Added a 20-minute timeout for a specific documentation build step in `.github/workflows/altdoc.yaml`.