### PR TITLE
version-check: add permission needed for private repos

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -17,6 +17,7 @@ jobs:
       GITHUB_PAT: ${{ github.token }}
     permissions:
       pull-requests: read
+      contents: read # needed for private repos
 
     steps:
 


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. It adds read permissions for repository contents, which is necessary for workflows running on private repositories.