### PR TITLE
update badges

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,8 @@ cat(
   badge_cran_release(),
   badge_cran_download(type = "grand-total"),
   badge_cran_download(type = "last-month"),
-  badge_cran_download(type = "last-week")
+  badge_cran_download(type = "last-week"),
+  badger::badge_license()
 )
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,12 +20,11 @@ knitr::opts_chunk$set(
 ```{r, echo = FALSE, message = FALSE, results='asis'}
 library(badger)
 cat(
+  badge_lifecycle(stage = "experimental", alt = "Lifecycle: experimental"),
   badge_github_actions(alt = "R-CMD-check", action = "R-CMD-check.yaml"),
   badge_codecov(alt = "Codecov test coverage", branch = "main"),
   badge_codefactor(alt = "CodeFactor", ref = "ucd-serg/rpt"), # case matters
   badge_cran_release(alt = "CRAN status"),
-  badge_lifecycle(stage = "experimental", alt = "Lifecycle: experimental"),
-  badge_cran_release(),
   badge_cran_download(type = "grand-total"),
   badge_cran_download(type = "last-month"),
   badge_cran_download(type = "last-week"),

--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@
 
 <!-- badges: start -->
 
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/UCD-SERG/rpt/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/UCD-SERG/rpt/actions)
 [![Codecov test
 coverage](https://codecov.io/gh/UCD-SERG/rpt/branch/main/graph/badge.svg)](https://app.codecov.io/gh/UCD-SERG/rpt)
 [![CodeFactor](https://www.codefactor.io/repository/github/ucd-serg/rpt/badge)](https://www.codefactor.io/repository/github/ucd-serg/rpt)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/rpt)](https://cran.r-project.org/package=rpt)
-[![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![](https://www.r-pkg.org/badges/version/rpt)](https://cran.r-project.org/package=rpt)
 [![](http://cranlogs.r-pkg.org/badges/grand-total/rpt)](https://cran.r-project.org/package=rpt)
 [![](http://cranlogs.r-pkg.org/badges/last-month/rpt)](https://cran.r-project.org/package=rpt)
 [![](http://cranlogs.r-pkg.org/badges/last-week/rpt)](https://cran.r-project.org/package=rpt)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 [![](http://cranlogs.r-pkg.org/badges/grand-total/rpt)](https://cran.r-project.org/package=rpt)
 [![](http://cranlogs.r-pkg.org/badges/last-month/rpt)](https://cran.r-project.org/package=rpt)
 [![](http://cranlogs.r-pkg.org/badges/last-week/rpt)](https://cran.r-project.org/package=rpt)
+[![License:
+MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://cran.r-project.org/web/licenses/MIT)
 
 <!-- badges: end -->
 


### PR DESCRIPTION
This pull request updates the badges displayed in both the `README.Rmd` and `README.md` files to improve clarity and provide more information. The main changes involve reordering existing badges, removing duplicates, and adding a new license badge.

Badge updates and improvements:

* Added a license badge (MIT) to both `README.Rmd` and `README.md` for clearer license visibility. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fR23-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8-R20)
* Reordered and deduplicated badges in both files for better organization and to avoid repetition. [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fR23-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8-R20)

closes #94 