### PR TITLE
Change wait-for-pages-deployment to false

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -147,7 +147,7 @@ jobs:
           source-dir: docs
           preview-branch: ${{ env.PREVIEW_BRANCH }}
           comment: "false"
-          wait-for-pages-deployment: true
+          wait-for-pages-deployment: false
 
       # following https://github.com/rossjrw/pr-preview-action?tab=readme-ov-file#customise-the-sticky-comment:
       - uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
This pull request makes a minor adjustment to the documentation deployment workflow by changing the behavior of the preview deployment step.

* Workflow configuration:
  * In `.github/workflows/docs.yaml`, the `wait-for-pages-deployment` option is now set to `false`, so the workflow will no longer wait for the GitHub Pages deployment to complete before proceeding.