### PR TITLE
Add GH_TOKEN to Quarto setup step

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -95,6 +95,8 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           tinytex: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify development environment
         if: steps.check_label.outputs.skip != 'true'


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. It sets the `GH_TOKEN` environment variable for the Quarto setup step, which may be needed for authentication when using GitHub resources in that step.

* [`.github/workflows/copilot-setup-steps.yml`](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR98-R99): Set the `GH_TOKEN` environment variable using the repository's `GITHUB_TOKEN` secret for the Quarto setup action.