### PR TITLE
Update version-check.yaml and news.yaml

### DIFF
--- a/.github/workflows/news.yaml
+++ b/.github/workflows/news.yaml
@@ -4,6 +4,9 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+    paths-ignore:
+      - '.github/workflows/**'
+      
 jobs:
   Check-Changelog:
     name: Check Changelog Action

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -5,6 +5,9 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'vignettes/**'
 
 name: Version increment check
 


### PR DESCRIPTION
This pull request updates the workflow triggers in our GitHub Actions configuration to prevent unnecessary runs when changes are made to workflow or documentation files. The main improvement is the addition of `paths-ignore` filters, which help reduce redundant CI runs and improve overall efficiency.

**Workflow trigger improvements:**

* Added `paths-ignore` to `.github/workflows/news.yaml` so the workflow does not run when only files in `.github/workflows/**` are changed.
* Added `paths-ignore` to `.github/workflows/version-check.yaml` to ignore changes in both `.github/workflows/**` and `vignettes/**`, preventing the workflow from running on changes to workflow or vignette files.