### PR TITLE
Include main branch ruleset as part of the template

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,48 @@
+# Branch rulesets
+
+Each JSON file here is a GitHub branch ruleset exported from the template's
+canonical configuration. Apply them to a new repo (after creating it from
+the template) with:
+
+```sh
+.github/scripts/apply-rulesets.sh                 # current repo
+.github/scripts/apply-rulesets.sh owner/repo      # explicit target
+```
+
+The script is idempotent — re-running it updates a ruleset in place when
+one with the same `name` already exists, rather than creating a duplicate.
+
+Requirements:
+
+- `gh` CLI authenticated as a repo admin (org or user). Branch rulesets
+  require admin scope to create.
+- `jq` available on PATH.
+
+## What's enforced (`main.json`)
+
+Applies to the default branch:
+
+- **Required PR before merging** — no direct pushes to `main`.
+- **Required status checks** (strict / branch-up-to-date):
+  R-CMD-check on ubuntu/macos/windows (`release`), Spellcheck, Check
+  Changelog Action, lint-changed-files, docs.
+- **No force-pushes, no branch deletion.**
+- **Copilot code review** runs on every push and on draft PRs.
+- **Bypass** in `pull_request` mode for the Maintain (role id 2) and Admin
+  (role id 5) roles — these roles can still merge via a PR they authored,
+  but cannot push directly.
+
+## Editing the ruleset
+
+Edit `main.json` here, then run `apply-rulesets.sh` to push the change to
+the live repo. Or edit in the GitHub UI (Settings → Rules → Rulesets) and
+re-export with:
+
+```sh
+gh api repos/OWNER/REPO/rulesets/RULESET_ID \
+  | jq 'del(.id, .node_id, .source, .source_type, .created_at, .updated_at, ._links, .current_user_can_bypass)' \
+  > .github/rulesets/main.json
+```
+
+The fields stripped by `jq del(...)` are server-assigned and would either
+be ignored or rejected by the create/update endpoints.

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,93 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "macos-latest (release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "ubuntu-latest (release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "windows-latest (release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Spellcheck",
+            "integration_id": 15368
+          },
+          {
+            "context": "Check Changelog Action",
+            "integration_id": 15368
+          },
+          {
+            "context": "lint-changed-files",
+            "integration_id": 15368
+          },
+          {
+            "context": "docs",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": true
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 2,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/.github/scripts/apply-rulesets.sh
+++ b/.github/scripts/apply-rulesets.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Apply branch rulesets from .github/rulesets/*.json to the current repo.
+# Run once after creating a new repo from this template. Idempotent: a
+# ruleset whose `name` already exists on the repo is updated in place rather
+# than duplicated.
+#
+# Requires: gh CLI authenticated with admin access to the repo.
+# Usage:    .github/scripts/apply-rulesets.sh [owner/repo]
+#           Defaults to the gh-detected current repo.
+
+set -euo pipefail
+
+repo="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+ruleset_dir="$(cd "$(dirname "$0")/../rulesets" && pwd)"
+
+shopt -s nullglob
+files=("$ruleset_dir"/*.json)
+if [ ${#files[@]} -eq 0 ]; then
+  echo "no rulesets found in $ruleset_dir" >&2
+  exit 0
+fi
+
+# Map of existing ruleset name -> id, so we can PUT updates instead of
+# creating duplicates.
+existing=$(gh api "repos/$repo/rulesets" --jq '[.[] | {name, id}]')
+
+for f in "${files[@]}"; do
+  name=$(jq -r .name "$f")
+  id=$(jq -r --arg n "$name" 'map(select(.name == $n)) | .[0].id // empty' <<<"$existing")
+  if [ -n "$id" ]; then
+    echo "updating ruleset '$name' (id $id) on $repo"
+    gh api -X PUT "repos/$repo/rulesets/$id" --input "$f" >/dev/null
+  else
+    echo "creating ruleset '$name' on $repo"
+    gh api -X POST "repos/$repo/rulesets" --input "$f" >/dev/null
+  fi
+done
+
+echo "done."

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -69,6 +69,7 @@ Replace `packagename` with your actual package name in:
 - [ ] Enable GitHub Actions in repository settings
 - [ ] Set up Codecov (optional): add CODECOV_TOKEN secret
 - [ ] Enable GitHub Pages for altdoc site
+- [ ] Apply branch rulesets: `.github/scripts/apply-rulesets.sh` (requires admin access; see `.github/rulesets/README.md`)
 - [ ] Create initial release/tag when ready
 - [ ] Add repository topics/tags
 


### PR DESCRIPTION
## Summary
- Export the live `main` branch ruleset to `.github/rulesets/main.json` (server-assigned fields stripped so it round-trips through the create/update endpoints).
- New `.github/scripts/apply-rulesets.sh` idempotently applies every JSON in `.github/rulesets/` to the current repo — PUT to update an existing ruleset by name, POST to create.
- New `.github/rulesets/README.md` documents what's enforced (required CI checks, no force-push, copilot code review, Maintain/Admin PR-only bypass) and how to re-export after editing in the UI.
- `CHECKLIST.md`: add a one-line entry under "GitHub Setup" pointing to the script.

## Test plan
- [ ] Create a throwaway repo from the template and run `.github/scripts/apply-rulesets.sh` against it — verify the ruleset shows up under Settings → Rules → Rulesets with all required status checks listed.
- [ ] Re-run the script — confirm it updates in place rather than creating a duplicate.
- [ ] Edit a rule in `.github/rulesets/main.json`, run the script, confirm the change appears in the GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)