### PR TITLE
ci: auto-update the macros submodule and GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keep git submodules up to date automatically.
+#
+# This template embeds the shared `macros` repo as a git submodule (at
+# `vignettes/macros/`). Dependabot's `gitsubmodule` updater opens a PR whenever a
+# submodule's tracked branch (here, `main`) advances, so neither this template
+# nor the packages generated from it have to bump the pointer by hand. See the
+# ADR at d-morrison/macros (docs/adr/0001-macros-submodule-versioning.md) for why
+# we track `main` rather than a pinned release tag.
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(submodule)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 #
 # This template embeds the shared `macros` repo as a git submodule (at
 # `vignettes/macros/`). Dependabot's `gitsubmodule` updater opens a PR whenever a
-# submodule's tracked branch (here, `main`) advances, so neither this template
+# submodule's default branch (currently `main`) advances, so neither this template
 # nor the packages generated from it have to bump the pointer by hand. See the
 # ADR at d-morrison/macros (docs/adr/0001-macros-submodule-versioning.md) for why
 # we track `main` rather than a pinned release tag.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Keep git submodules up to date automatically.
+# Keep git submodules and pinned GitHub Actions up to date automatically.
 #
 # This template embeds the shared `macros` repo as a git submodule (at
 # `vignettes/macros/`). Dependabot's `gitsubmodule` updater opens a PR whenever a
@@ -14,3 +14,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(submodule)"
+
+  # Also keep pinned GitHub Actions current. Dependabot scans .github/workflows/
+  # and opens a PR when a newer release of a pinned action is available;
+  # unversioned @HEAD / @main pins are left untouched.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(actions)"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9020
+Version: 0.0.0.9021
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 - Added a committed Claude Code configuration (`.claude/`) and a `CLAUDE.md`
   guidance file, so packages created from this template inherit slash commands,
   safe execution permissions, and a PR-review skill out of the box.
+- Added a Dependabot configuration (`.github/dependabot.yml`) that keeps the
+  `macros` git submodule up to date automatically: Dependabot opens a PR
+  whenever the submodule advances, so packages created from this template
+  inherit hands-off submodule bumps.
 - Updated README to cover new template features:
   - Working examples for `example_function()` and `calculate_summary()`
   - Multi-format Quarto vignettes/articles (HTML, RevealJS slides, DOCX)

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,9 +12,10 @@
   guidance file, so packages created from this template inherit slash commands,
   safe execution permissions, and a PR-review skill out of the box.
 - Added a Dependabot configuration (`.github/dependabot.yml`) that keeps the
-  `macros` git submodule up to date automatically: Dependabot opens a PR
-  whenever the submodule advances, so packages created from this template
-  inherit hands-off submodule bumps.
+  `macros` git submodule and the pinned GitHub Actions in `.github/workflows/`
+  up to date automatically: Dependabot opens a PR whenever the submodule
+  advances or a newer action release is available, so packages created from
+  this template inherit hands-off submodule and action bumps.
 - Updated README to cover new template features:
   - Working examples for `example_function()` and `calculate_summary()`
   - Multi-format Quarto vignettes/articles (HTML, RevealJS slides, DOCX)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -13,6 +13,7 @@ Cov
 Covf
 Covs
 Covt
+Dependabot
 Devn
 DiagrammeR
 DOCX


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with **two** Dependabot ecosystems, so this template (and packages generated from it) get hands-off dependency updates:

- **`gitsubmodule`** — bumps the `macros` submodule (at `vignettes/macros/`) when its default branch advances, removing the manual `git submodule update --remote` + commit step.
- **`github-actions`** — bumps pinned action versions in `.github/workflows/` (e.g. `actions/checkout`, `r-lib/actions/*`, `quarto-dev/quarto-actions/*`).

Both run weekly; unversioned `@HEAD`/`@main` action pins are left untouched. `NEWS.md` and the dev version are updated to match.

## Why track `main` for the submodule

Follow-through on the ADR in [`d-morrison/macros`](https://github.com/d-morrison/macros/blob/main/docs/adr/0001-macros-submodule-versioning.md): a sliding tag wouldn't remove the manual bump (a gitlink only advances when a consumer updates *and commits* it), and Dependabot tracks a **branch**, which is the only ref that style of tracking can follow.

## Config

```yaml
updates:
  - package-ecosystem: "gitsubmodule"
    directory: "/"
    schedule: { interval: "weekly" }
    commit-message: { prefix: "chore(submodule)" }
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule: { interval: "weekly" }
    commit-message: { prefix: "chore(actions)" }
```

> This branch also merges `main`, which includes the docs-build fix ([#145](https://github.com/d-morrison/rpt/pull/145)), so the `docs` job is green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN