### PR TITLE
ci(docs): install quarto R package from quarto-dev/quarto-r (fix docs job)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -83,7 +83,7 @@ jobs:
             website
           extra-packages: |
             d-morrison/altdoc@recursive-qmd-search
-            quarto-dev/quarto
+            quarto-dev/quarto-r
             any::sessioninfo
             local::.
 


### PR DESCRIPTION
## Summary

Fixes the failing `docs` job (e.g. [this run](https://github.com/d-morrison/rpt/actions/runs/27863803594/job/82464306869)).

## Root cause

`.github/workflows/docs.yaml` listed `quarto-dev/quarto` as an R `extra-package` for `r-lib/actions/setup-r-dependencies`. But `quarto-dev/quarto` is the **Quarto CLI** repo, not an R package, so `pak` fails dependency resolution:

```
! Can't find R package in GitHub repo quarto-dev/quarto
* quarto: Conflicts with quarto-dev/quarto
```

It also conflicts with the real CRAN `quarto` package that `altdoc`/`local::.` pull in. This was latent until an upstream resolver change started rejecting it — the `docs` job last passed on **2026-05-27** on the same base commit, then began failing on every PR/push (upstream drift, not a code change here).

## Fix

The R `quarto` package lives at **`quarto-dev/quarto-r`**. Point the dev-version install there, preserving the intent of installing the dev `quarto` from GitHub (paired with the dev `d-morrison/altdoc@recursive-qmd-search` fork).

One-line change; scoped to `.github/workflows/docs.yaml` only (so the changelog/version-check gates correctly skip it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN)_