### PR TITLE
Refresh CLAUDE.md to current repo state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,11 @@ Authoritative style guide: [UCD-SERG Lab Manual](https://ucd-serg.github.io/lab-
 This template documents the package with [altdoc](https://altdoc.etiennebacher.com/)
 + Quarto (not pkgdown):
 
-- `altdoc::render_docs()` generates man-page `.qmd` files from `man/*.Rd` at
-  build time, then invokes Quarto (project root `altdoc/`,
-  `altdoc/quarto_website.yml`) to render the site into `docs/`. Both the
-  generated man `.qmd` and the `docs/` output are gitignored — **not** committed.
+- `altdoc::render_docs()` generates man-page `.qmd` files (under `altdoc/man/`)
+  from `man/*.Rd` at build time, then invokes Quarto (project root `altdoc/`,
+  `altdoc/quarto_website.yml`) to render the site into `docs/`. The `docs/`
+  output is gitignored; the generated man `.qmd` files are regenerated each
+  build — **neither** is committed.
 - For doc or vignette changes, build and preview locally before requesting
   review: `altdoc::render_docs(verbose = TRUE)`, then `altdoc::preview_docs()`,
   and visually confirm the rendered site (math, code highlighting, links, nav).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Authoritative style guide: [UCD-SERG Lab Manual](https://ucd-serg.github.io/lab-
 - `R/`, `man/`, `NAMESPACE`, `DESCRIPTION` — R package source and generated docs
 - `tests/testthat/` — testthat suite (use snapshot tests where helpful)
 - `vignettes/` — package vignettes and `.qmd` articles
-- `altdoc/` — altdoc + Quarto documentation site config
+- `altdoc/` — altdoc + Quarto documentation site config (`quarto_website.yml`, `index.qmd`, post-render scripts)
 - `data-raw/` — scripts that generate package data
 - `inst/WORDLIST` — accepted spell-check terms
 - `.github/workflows/` — CI workflow definitions
@@ -31,9 +31,13 @@ Authoritative style guide: [UCD-SERG Lab Manual](https://ucd-serg.github.io/lab-
 This template documents the package with [altdoc](https://altdoc.etiennebacher.com/)
 + Quarto (not pkgdown):
 
-- `altdoc::render_docs()` generates `.qmd` files into `altdoc/man/` at build
-  time from `man/*.Rd`, then invokes Quarto to render the site. The generated
-  `altdoc/man/*.qmd` are **not** committed.
+- `altdoc::render_docs()` generates man-page `.qmd` files from `man/*.Rd` at
+  build time, then invokes Quarto (project root `altdoc/`,
+  `altdoc/quarto_website.yml`) to render the site into `docs/`. Both the
+  generated man `.qmd` and the `docs/` output are gitignored — **not** committed.
+- For doc or vignette changes, build and preview locally before requesting
+  review: `altdoc::render_docs(verbose = TRUE)`, then `altdoc::preview_docs()`,
+  and visually confirm the rendered site (math, code highlighting, links, nav).
 - `.github/workflows/docs.yaml` builds and deploys the site: pushes to `main`
   go to `/dev/`, releases to `/`, and each PR gets a preview at
   `/preview/pr<number>/` via `rossjrw/pr-preview-action`. A `Versions` navbar

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9022
+Version: 0.0.0.9023
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9021
+Version: 0.0.0.9022
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )


### PR DESCRIPTION
Conservative refresh of `CLAUDE.md` to match the repo's current state. Targeted edits only; structure and voice preserved, and it still points to `.github/copilot-instructions.md` as the source of truth.

Changes:

- Corrected the altdoc documentation notes. `altdoc::render_docs()` generates man-page `.qmd` from `man/*.Rd` and Quarto (project root `altdoc/`, `quarto_website.yml`) renders the site into `docs/`; both the generated man `.qmd` and `docs/` are gitignored, not committed. The old text said the site was generated into `altdoc/man/` and never mentioned `docs/`.
- Added the local build-and-preview step (`altdoc::render_docs(verbose = TRUE)` then `altdoc::preview_docs()`) that copilot-instructions.md treats as mandatory before review.
- Named `quarto_website.yml` in the `altdoc/` layout entry.

Verified the rest is still accurate: the listed slash commands (`/document`, `/lint`, `/spell`, `/test`, `/check`) all exist under `.claude/commands/`; `R-check-docs.yml`, `news.yaml`, and the `docs.yaml` PR-preview / version-dropdown details match the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P5jndYuYhLVGPp1e9CEcp

---
_Generated by [Claude Code](https://claude.ai/code/session_012P5jndYuYhLVGPp1e9CEcp)_