### PR TITLE
Fix broken badges on docs homepage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,8 @@ Authors@R: c(
   )
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE
-URL: https://github.com/UCD-SERG/rpt, https://ucd-serg.github.io/rpt/
-BugReports: https://github.com/UCD-SERG/rpt/issues
+URL: https://github.com/d-morrison/rpt, https://d-morrison.github.io/rpt/
+BugReports: https://github.com/d-morrison/rpt/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9023
+Version: 0.0.0.9024
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rpt (development version)
 
+- Fixed README/site badges for this fork by pointing badge URLs at
+  `d-morrison/rpt`, removing fork-invalid CodeFactor/CRAN badges, and updating
+  package URLs in `DESCRIPTION` (#160).
+
 - Every CI workflow job now sets a `timeout-minutes` cap of at most 50, so a
   runaway or hung job can no longer tie up a runner indefinitely. The convention
   is documented in `.github/copilot-instructions.md` (#75).

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,11 +23,6 @@ cat(
   badge_lifecycle(stage = "experimental", alt = "Lifecycle: experimental"),
   badge_github_actions(alt = "R-CMD-check", action = "R-CMD-check.yaml"),
   badge_codecov(alt = "Codecov test coverage", branch = "main"),
-  badge_codefactor(alt = "CodeFactor", ref = "ucd-serg/rpt"), # case matters
-  badge_cran_release(alt = "CRAN status"),
-  badge_cran_download(type = "grand-total"),
-  badge_cran_download(type = "last-month"),
-  badge_cran_download(type = "last-week"),
   badger::badge_license()
 )
 ```

--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@
 
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R-CMD-check](https://github.com/UCD-SERG/rpt/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/UCD-SERG/rpt/actions)
+[![R-CMD-check](https://github.com/d-morrison/rpt/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/d-morrison/rpt/actions)
 [![Codecov test
-coverage](https://codecov.io/gh/UCD-SERG/rpt/branch/main/graph/badge.svg)](https://app.codecov.io/gh/UCD-SERG/rpt)
-[![CodeFactor](https://www.codefactor.io/repository/github/ucd-serg/rpt/badge)](https://www.codefactor.io/repository/github/ucd-serg/rpt)
-[![CRAN
-status](https://www.r-pkg.org/badges/version/rpt)](https://cran.r-project.org/package=rpt)
-[![](http://cranlogs.r-pkg.org/badges/grand-total/rpt)](https://cran.r-project.org/package=rpt)
-[![](http://cranlogs.r-pkg.org/badges/last-month/rpt)](https://cran.r-project.org/package=rpt)
-[![](http://cranlogs.r-pkg.org/badges/last-week/rpt)](https://cran.r-project.org/package=rpt)
+coverage](https://codecov.io/gh/d-morrison/rpt/branch/main/graph/badge.svg)](https://app.codecov.io/gh/d-morrison/rpt)
 [![License:
 MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://cran.r-project.org/web/licenses/MIT)
 

--- a/man/rpt-package.Rd
+++ b/man/rpt-package.Rd
@@ -11,9 +11,9 @@ What the package does (one paragraph).
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/UCD-SERG/rpt}
-  \item \url{https://ucd-serg.github.io/rpt/}
-  \item Report bugs at \url{https://github.com/UCD-SERG/rpt/issues}
+  \item \url{https://github.com/d-morrison/rpt}
+  \item \url{https://d-morrison.github.io/rpt/}
+  \item Report bugs at \url{https://github.com/d-morrison/rpt/issues}
 }
 
 }


### PR DESCRIPTION
## Summary
- keep README badges generated via `badger` in `README.Rmd`
- remove CodeFactor and CRAN badges that are invalid/broken for this fork
- update `DESCRIPTION` URLs so generated badge links point at `d-morrison/rpt`
- regenerate `README.md` from `README.Rmd`

## Why
The docs homepage (`https://d-morrison.github.io/rpt/`) includes `README.md`, so broken badge targets in the README render as broken badges on the site.