### PR TITLE
Prepare v1.0.2 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9024
+Version: 1.0.2
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
-# rpt (development version)
+# rpt 1.0.2
 
 - Fixed README/site badges for this fork by pointing badge URLs at
   `d-morrison/rpt`, removing fork-invalid CodeFactor/CRAN badges, and updating
   package URLs in `DESCRIPTION` (#160).
+- Released `v1.0.2` to validate multiversion documentation deployment,
+  including stable `/`, development `/dev/`, and versioned release docs
+  (`/v1.0.2/`) (#161).
 
 - Every CI workflow job now sets a `timeout-minutes` cap of at most 50, so a
   runaway or hung job can no longer tie up a runner indefinitely. The convention


### PR DESCRIPTION
## Summary
- set `DESCRIPTION` to release version `1.0.2`
- record the `v1.0.2` release in `NEWS.md`
- use this release to validate stable (`/`), development (`/dev/`), and versioned (`/v1.0.2/`) multiversion docs deployment

## Why
This prepares a lightweight release from the current main branch so we can verify that the multiversion docs workflow publishes the expected stable and archived docs variants.

Closes #161