### PR TITLE
Bump development version after v1.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 1.0.2
+Version: 1.0.2.9000
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
-# rpt 1.0.2
+# rpt (development version)
 
+- Bumped the development version to `1.0.2.9000` after the `v1.0.2` release so
+  `/dev/` docs stay labeled with the live development version.
 - Fixed README/site badges for this fork by pointing badge URLs at
   `d-morrison/rpt`, removing fork-invalid CodeFactor/CRAN badges, and updating
   package URLs in `DESCRIPTION` (#160).


### PR DESCRIPTION
## Summary
- bump `DESCRIPTION` to `1.0.2.9000`
- switch `NEWS.md` back to the development header
- keep `/dev/` docs labeled with the live development version after publishing `v1.0.2`

## Why
The release docs workflow reads `origin/main:DESCRIPTION` to label the development docs entry. Merging this before publishing the `v1.0.2` GitHub release ensures stable docs come from the tagged release while `/dev/` stays labeled as the post-release development line.