### PR TITLE
Fix hard-coded docs base URL in version dropdown generator

### DIFF
--- a/.github/scripts/generate_version_dropdown.py
+++ b/.github/scripts/generate_version_dropdown.py
@@ -15,9 +15,6 @@ import sys
 import os
 from pathlib import Path
 
-# Base URL for the deployed documentation site.
-# Update this when adapting the template for a different repository.
-BASE_URL = "https://ucd-serg.github.io/rpt/"
 REPO_DIR = Path(os.environ.get("DOCS_SOURCE_DIR", ".")).resolve()
 
 # --- Helpers ---
@@ -44,6 +41,29 @@ def _run_git(*args):
         print(f"Failed to execute git command: {e}", file=sys.stderr)
         sys.exit(1)
 
+
+def _docs_base_url():
+    """Return the GitHub Pages base URL used for docs links."""
+    configured_url = os.environ.get("DOCS_BASE_URL", "").strip()
+    if configured_url:
+        return configured_url.rstrip("/") + "/"
+
+    repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if "/" in repository:
+        owner, repo = repository.split("/", 1)
+        if owner and repo:
+            return f"https://{owner}.github.io/{repo}/"
+
+    owner = os.environ.get("GITHUB_REPOSITORY_OWNER", "").strip()
+    repo = os.environ.get("GITHUB_EVENT_REPOSITORY_NAME", "").strip()
+    if owner and repo:
+        return f"https://{owner}.github.io/{repo}/"
+
+    # Fallback for local runs without GitHub Actions metadata.
+    return "https://d-morrison.github.io/rpt/"
+
+
+BASE_URL = _docs_base_url()
 
 # --- Gather version information ---
 


### PR DESCRIPTION
## Summary
- replace hard-coded docs base URL in `.github/scripts/generate_version_dropdown.py`
- derive the base URL from `DOCS_BASE_URL` when set, otherwise from GitHub repository metadata
- keep a local-run fallback defaulting to `https://d-morrison.github.io/rpt/`

Closes #164