### PR TITLE
Add the new-issue summary workflow

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -1,0 +1,15 @@
+# Summarize newly opened issues, via the reusable workflow in
+# d-morrison/gha rather than a repo-local copy (#74).
+name: Summarize new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  summary:
+    permissions:
+      issues: write
+      models: read
+      contents: read
+    uses: d-morrison/gha/.github/workflows/summary.yml@v1


### PR DESCRIPTION
Fixes #74

Adds a `Summarize new issues` workflow that posts a one-paragraph summary as
a comment when an issue is opened.

## Calls the reusable workflow instead of copying qbt's

#74 asked to bring over
[qbt's `summary.yml`](https://github.com/UCD-SERG/qbt/blob/main/.github/workflows/summary.yml).
That pattern has since been generalized into
[`d-morrison/gha`](https://github.com/d-morrison/gha)'s
`summary.yml` reusable workflow, so this repo gets a 15-line caller stub
rather than its own copy of the prompt and its
untrusted-data handling (the gha version wraps the issue body in
randomized-nonce delimiters so an issue author cannot escape the data
boundary by pasting the delimiter string).

One copy also means a future fix to that prompt reaches every consumer
rather than only whichever repo it was noticed in.

**This is the first gha reusable workflow this repo consumes** -- `grep -r
"d-morrison/gha" .github/` returns nothing on `main` today. #169's
`docs.yaml` migration would be the second and much larger one.

Pinned `@v1`: `summary.yml` is not among the capabilities gha moved to
`@v2` (see its README's Versioning section).

## Checklist

- [x] Title briefly describes the change.
- [x] Body contains `Fixes #74`.
- [ ] NEWS.md bullet -- not applicable: `news.yaml` sets
      `paths-ignore: .github/workflows/**`, and this changes no
      user-visible package behavior. (`version-check.yaml` ignores the same
      path, so no version bump either.)
- [ ] roxygen2 docs / testthat tests -- not applicable: no R code changes.
      The workflow itself is exercised by gha's own CI.

## Verification

YAML parses, and the stub matches gha's documented
[`examples/summary.yml`](https://github.com/d-morrison/gha/blob/main/examples/summary.yml)
including the `issues: write` + `models: read` permissions the reusable
workflow requires. End-to-end behavior is only observable when an issue is
actually opened, so that is the first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STj9WXmMhat4rEvVN9sdn3

---
_Generated by [Claude Code](https://claude.ai/code/session_01STj9WXmMhat4rEvVN9sdn3)_