### PR TITLE
Ask for rendered-site screenshots in PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -127,11 +127,6 @@ altdoc::preview_docs()    # Launch preview server
 
 # Only commit and push if all checks pass AND visual inspection confirms correct rendering
 ```
-# Check docs/vignettes/*.md for correct output
-# Verify links and images work correctly
-
-# Only commit and push if all checks pass AND visual inspection confirms correct rendering
-```
 
 ## Package Structure
 
@@ -225,6 +220,27 @@ Instead of just changing `@v2.9.4` to `@v2`, include in your commit message or P
 > "Using @v2 (moving tag) instead of @v2.9.4 (pinned version) to automatically receive bug fixes and updates within the v2 major version while maintaining stability."
 
 This proactive communication prevents reviewers from needing to ask clarifying questions and helps future maintainers understand the decisions made.
+
+### Screenshots of the Rendered Site
+
+When a change affects the rendered documentation site, include screenshots of
+the affected pages in the pull request, whenever possible. A reviewer can then
+see the result without checking out the branch and running
+`altdoc::render_docs()` themselves.
+
+This applies to any change whose effect is visual: vignette or article prose,
+math rendering, figures, navbar and sidebar structure, theming, or the version
+dropdown.
+
+- Prefer the **PR preview deployment** over a local screenshot when one is
+  available -- `docs.yaml` posts its URL as a sticky comment, and a link to the
+  specific affected page lets the reviewer click straight to it.
+- Screenshot the **specific element that changed**, not the whole page, when
+  the change is small.
+- For a change to existing output, a **before/after pair** is far more useful
+  than the after alone.
+- Say so explicitly when a change *cannot* be shown this way (a build-time
+  fix with no visual result), so silence is not mistaken for an oversight.
 
 ### Before Requesting Human Review
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 1.0.2.9001
+Version: 1.0.2.9002
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rpt (development version)
 
+- Contributing docs now ask for screenshots of the rendered documentation
+  site on pull requests that change it, preferring a link into the PR-preview
+  deployment over a local capture, and repair an unbalanced code fence that
+  was making several sections of `.github/copilot-instructions.md` render as
+  a code block (#43).
+
 - `_docs_base_url()` in the version dropdown generator
   (`.github/scripts/generate_version_dropdown.py`) now warns on `stderr` when
   it falls back to the hard-coded `https://d-morrison.github.io/rpt/` default


### PR DESCRIPTION
Fixes #43

Adds the requested guidance to `copilot-instructions.md`, which this repo's
`CLAUDE.md` names as the source of truth for contribution conventions, under
the existing **Explaining Changes in Pull Requests** section.

Beyond restating "attach screenshots", it says the things that make the
practice actually useful: prefer a link into the PR-preview deployment
`docs.yaml` already publishes over a local screenshot, screenshot the element
that changed rather than the page, favor before/after pairs for changes to
existing output, and say so explicitly when a change has no visual result so
silence is not read as an oversight.

## Also in this PR: an unbalanced code fence in the same file

Disclosed rather than folded in silently, since it is unrelated to #43 beyond
living in the file it edits.

`copilot-instructions.md` had **11** code fences -- an odd number. A
four-line fragment was duplicated *outside* the fence that closes the
validation-workflow example, followed by a second, unmatched fence:

````
# Only commit and push if all checks pass AND visual inspection confirms correct rendering
```                                            <- closes the r block
# Check docs/vignettes/*.md for correct output <- orphaned duplicate
# Verify links and images work correctly

# Only commit and push if all checks pass AND visual inspection confirms correct rendering
```                                            <- stray opening fence
````

That stray fence opened a block that ran until the next fence at the
**Development Workflow** example, so everything between -- "Package
Structure", "Code Style", and the sections after -- rendered as a code block
instead of prose. Removing the orphaned fragment and its fence brings the
count to 10.

## Checklist

- [x] Title briefly describes the change.
- [x] Body contains `Fixes #43`.
- [ ] NEWS.md bullet -- not applicable: no user-visible package behavior
      changes, and this file is contributor documentation.
- [ ] roxygen2 docs / testthat tests -- not applicable: no R code changes.

## Verification

Fence count is even (10), the added prose is ASCII-only (no em-dashes or
curly quotes, checked mechanically), and the new lines wrap well inside the
widths already present in the file.

Per its own new guidance: this change has **no rendered-site effect** --
`copilot-instructions.md` is not part of the documentation site -- so there
is nothing to screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STj9WXmMhat4rEvVN9sdn3

---
_Generated by [Claude Code](https://claude.ai/code/session_01STj9WXmMhat4rEvVN9sdn3)_