### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -1,5 +1,5 @@
 # Summarize newly opened issues, via the reusable workflow in
-# d-morrison/gha rather than a repo-local copy (#74).
+# Morrison-Lab/gha rather than a repo-local copy (#74).
 name: Summarize new issues
 
 on:
@@ -12,4 +12,4 @@ jobs:
       issues: write
       models: read
       contents: read
-    uses: d-morrison/gha/.github/workflows/summary.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/summary.yml@v1


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 2 reference(s) across 1 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.