### PR TITLE
chore: switch altdoc from recursive-qmd-search branch to main

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -86,7 +86,7 @@ jobs:
             any::spelling
             any::rmarkdown
             d-morrison/altdoc@main
-          needs: checkmain
+          needs: check
 
       # Set up Quarto - required for rendering the website
       - name: Set up Quarto

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -85,8 +85,8 @@ jobs:
             any::lintr
             any::spelling
             any::rmarkdown
-            d-morrison/altdoc@recursive-qmd-search
-          needs: check
+            d-morrison/altdoc@main
+          needs: checkmain
 
       # Set up Quarto - required for rendering the website
       - name: Set up Quarto

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -82,7 +82,7 @@ jobs:
               | sort -V \
               | tail -n 1
           )
-          echo "latest_stable_tag=$LATEST_STABLE_TAG" >> "$GITHUB_OUTPUT"
+          echo "latest_stable_mainAG" >> "$GITHUB_OUTPUT"
 
       - name: Validate stable workflow_dispatch input
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version == 'stable'
@@ -141,8 +141,13 @@ jobs:
             connect
             website
           extra-packages: |
+<<<<<<< Updated upstream
             d-morrison/altdoc@recursive-qmd-search
             quarto-dev/quarto-r
+=======
+            d-morrison/altdoc@main
+            quarto-dev/quarto
+>>>>>>> Stashed changes
             any::sessioninfo
             local::.
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -82,7 +82,7 @@ jobs:
               | sort -V \
               | tail -n 1
           )
-          echo "latest_stable_mainAG" >> "$GITHUB_OUTPUT"
+          echo "latest_stable_tag=$LATEST_STABLE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Validate stable workflow_dispatch input
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version == 'stable'
@@ -141,13 +141,8 @@ jobs:
             connect
             website
           extra-packages: |
-<<<<<<< Updated upstream
-            d-morrison/altdoc@recursive-qmd-search
-            quarto-dev/quarto-r
-=======
             d-morrison/altdoc@main
-            quarto-dev/quarto
->>>>>>> Stashed changes
+            quarto-dev/quarto-r
             any::sessioninfo
             local::.
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rpt
 Title: What the Package Does (One Line, Title Case)
-Version: 1.0.2.9002
+Version: 1.0.2.9003
 Authors@R: c(
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"))
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,4 @@ Suggests:
 Config/testthat/edition: 3
 VignetteBuilder: knitr, quarto
 Config/Needs/website: quarto
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rpt (development version)
 
+- Switch altdoc dependency from `d-morrison/altdoc@recursive-qmd-search`
+  to `d-morrison/altdoc@main` (268 commits ahead, 0 behind).
+
 - Contributing docs now ask for screenshots of the rendered documentation
   site on pull requests that change it, preferring a link into the PR-preview
   deployment over a local capture, and repair an unbalanced code fence that


### PR DESCRIPTION
The main branch of d-morrison/altdoc is 268 commits ahead of recursive-qmd-search and 0 behind. Switching to @main for both rpt and matt.contracts.